### PR TITLE
Improve Base Sepolia helper UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+diagnostics/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,159 @@
 # BaseBytes
+
 Ethical Data Rental On Base
+
+## Local utilities
+
+Install dependencies once:
+
+```bash
+npm install
+```
+
+### Derive the account address
+
+```bash
+# from environment variables
+export PRIVATE_KEY="0x..."
+npm run derive:address
+
+# or pass the key explicitly
+npm run derive:address -- --key 0x...
+
+# positional (legacy) usage is still supported
+node scripts/derive-address.js 0x...
+```
+
+### Verify the RPC network
+
+```bash
+# from environment variables
+export RPC_URL="https://..."
+npm run chain:check
+
+# or pass the RPC via flag / positional argument
+npm run chain:check -- --rpc https://...
+node scripts/check-chain-id.js https://...
+```
+
+Flags:
+
+- `--expect-chain-id=0x...` overrides the expected network (defaults to Base Sepolia `0x14a34`).
+- `--allow-chain-mismatch` permits continuing when the RPC reports a different chain.
+
+### Send a self-transaction
+
+```bash
+export RPC_URL="http://127.0.0.1:8545"
+export PRIVATE_KEY="0x..."
+npm run tx:self
+
+# pass inputs via flags (allows you to override env vars inline)
+npm run tx:self -- --rpc http://127.0.0.1:8545 --key 0x...
+
+# optional overrides: send to a custom recipient or specify the ETH amount
+npm run tx:self -- 0xRecipient 0.01 --rpc http://127.0.0.1:8545 --key 0x...
+```
+
+Additional options:
+
+- `--confirmations=<n>` (or `TX_CONFIRMATIONS` env var) to wait for a custom number of confirmations.
+- `--expect-chain-id=0x...` / `EXPECT_CHAIN_ID` to adjust the chain assertion.
+- `--allow-chain-mismatch` / `ALLOW_CHAIN_MISMATCH=true` to skip chain enforcement (not recommended for production).
+- `--to=<0x...>` / `SELF_TX_TO` to send to a specific recipient (defaults to the signer).
+- `--value=<eth>` / `SELF_TX_VALUE` to choose the transfer amount in ETH (defaults to `0`).
+
+Successful runs store diagnostics under `./diagnostics/` and echo a JSON summary.
+
+### One-shot automation prompt
+
+Paste the following snippet into a fresh shell (or Codex session) for an end-to-end workflow that installs dependencies if needed, checks the chain id, derives the account, and emits a 0-ETH self-transaction artifact. Provide your own RPC URL and private key first:
+
+```bash
+# one-shot self-transaction on Base Sepolia (or local anvil), with archiving and JSON summary
+cd /workspace/BaseBytes || exit 1
+set -euo pipefail
+
+# ---- toggles / inputs ----
+: "${SEND:=1}"
+: "${ALLOW_CHAIN_MISMATCH:=0}"
+: "${RPC_URL:=${BASE_RPC_URL:-}}"
+: "${PRIVATE_KEY:=${ATTESTER_PRIVATE_KEY:-}}"
+: "${SELF_ADDR:=${ATTESTER_ADDRESS:-}}"
+
+if [ ! -d node_modules ]; then
+  npm ci --silent || true
+fi
+
+if [ -z "${RPC_URL}" ] || [ -z "${PRIVATE_KEY}" ]; then
+  printf '{"phase":"gate","status":"MISSING_ENV","need":["RPC_URL","PRIVATE_KEY"]}\n'
+  exit 0
+fi
+case "$RPC_URL" in *\<*\>*)
+  printf '{"phase":"gate","status":"INVALID_RPC_URL","hint":"remove angle brackets; paste the raw RPC URL"}\n'
+  exit 0
+  ;;
+esac
+if ! printf '%s' "$PRIVATE_KEY" | grep -Eq '^0x[0-9a-fA-F]{64}$'; then
+  printf '{"phase":"gate","status":"INVALID_KEY","hint":"must be 0x + 64 hex chars"}\n'
+  exit 0
+fi
+
+CHAIN_HEX="$(curl -sS --max-time 8 -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' "$RPC_URL" \
+  | sed -n 's/.*"result":"\([^"]*\)".*/\1/p' | tr 'A-Z' 'a-z' || true)"
+if [ "${ALLOW_CHAIN_MISMATCH}" != "1" ] && [ "$CHAIN_HEX" != "0x14a34" ]; then
+  printf '{"phase":"rpc-check","status":"GATED","chainId":"%s","hint":"expected 0x14a34 (Base Sepolia) or set ALLOW_CHAIN_MISMATCH=1 for local"}\n' "${CHAIN_HEX:-unknown}"
+  exit 0
+fi
+
+if [ -z "${SELF_ADDR}" ]; then
+  SELF_ADDR="$(npm run --silent derive:address -- --key "$PRIVATE_KEY" || true)"
+fi
+if [ -z "${SELF_ADDR}" ]; then
+  printf '{"phase":"derive","status":"FAIL","reason":"could_not_derive_address"}\n'
+  exit 0
+fi
+
+if [ "${SEND}" != "1" ]; then
+  npm run tx:self -- "$SELF_ADDR" 0 --rpc "$RPC_URL" --key "$PRIVATE_KEY" --allow-chain-mismatch >/dev/null 2>&1 || true
+  printf '{"phase":"dry-run","from":"%s","rpcChain":"%s","note":"built & estimated ok (no broadcast)"}\n' "$(echo "$SELF_ADDR" | sed -E 's/(0x[0-9a-fA-F]{6}).+/\1…/')" "${CHAIN_HEX:-unknown}"
+  exit 0
+fi
+
+ts="$(date +%Y%m%dT%H%M%S)"
+mkdir -p diagnostics
+OUT="$(mktemp)"
+if npm run tx:self -- "$SELF_ADDR" 0 --rpc "$RPC_URL" --key "$PRIVATE_KEY" --allow-chain-mismatch >"$OUT" 2>&1; then
+  TXH="$(sed -n 's/.*"tx_hash_full":"\([^"]*\)".*/\1/p; t; s/.*"tx_hash":"\([^"]*\)".*/\1/p' "$OUT" | head -n1)"
+  STAT="$(sed -n 's/.*"status":"\([^"]*\)".*/\1/p' "$OUT" | head -n1)"
+  BLK="$(sed -n 's/.*"block":\([^,}]*\).*/\1/p' "$OUT" | head -n1)"
+  if [ -z "$TXH" ]; then
+    TXH="$(grep -Eo '0x[0-9a-fA-F]{64}' "$OUT" | head -n1 || true)"
+  fi
+  cat <<JSON >"diagnostics/tx_${ts}.json"
+{
+  "phase": "self-tx",
+  "network": "${CHAIN_HEX:-unknown}",
+  "from": "$(echo "$SELF_ADDR" | sed -E 's/(0x[0-9a-fA-F]{6}).+/\1…/')",
+  "to": "$(echo "$SELF_ADDR" | sed -E 's/(0x[0-9a-fA-F]{6}).+/\1…/')",
+  "tx_hash": "${TXH:-}",
+  "status": "${STAT:-unknown}",
+  "block": ${BLK:-null}
+}
+JSON
+  EXPL=""
+  if [ "$CHAIN_HEX" = "0x14a34" ] && [ -n "$TXH" ]; then
+    EXPL="https://sepolia.basescan.org/tx/${TXH}"
+  fi
+  printf '{"phase":"tx","saved":"diagnostics/tx_%s.json","status":"%s","block":%s,"explorer":"%s"}\n' \
+    "$ts" "${STAT:-unknown}" "${BLK:-null}" "${EXPL:-}"
+else
+  if grep -qE 'ENETUNREACH|ECONNREFUSED|network|fetch failed' "$OUT"; then
+    printf '{"phase":"tx","status":"NETWORK_ERROR","detail":"%s"}\n' "$(tr -d '\n' <"$OUT" | sed 's/"/\\"/g' | head -c 400)"
+  else
+    printf '{"phase":"tx","status":"ERROR","detail":"%s"}\n' "$(tr -d '\n' <"$OUT" | sed 's/"/\\"/g' | head -c 400)"
+  fi
+  exit 1
+fi
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,122 @@
+{
+  "name": "basebytes",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "basebytes",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ethers": "^6.15.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/ethers": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
+      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "basebytes",
+  "version": "1.0.0",
+  "description": "Ethical Data Rental On Base",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "chain:check": "node scripts/check-chain-id.js",
+    "derive:address": "node scripts/derive-address.js",
+    "tx:self": "node scripts/send-self-tx.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "ethers": "^6.15.0"
+  }
+}

--- a/scripts/check-chain-id.js
+++ b/scripts/check-chain-id.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+'use strict';
+
+const { JsonRpcProvider } = require('ethers');
+const {
+  ensureChainId,
+  extractErrorMessage,
+  parseCliArgs,
+  pickInput,
+  resolveExpectedChainId,
+  shouldAllowChainMismatch
+} = require('./utils');
+
+const { positionals, flags } = parseCliArgs(process.argv.slice(2));
+
+let rpcUrl;
+try {
+  rpcUrl = pickInput({
+    envKey: 'RPC_URL',
+    flagKeys: ['rpc', 'rpc-url', 'url', 'provider'],
+    flags,
+    positionals,
+    positionalTest: (value) => typeof value === 'string' && /^(https?:|wss?:)/i.test(value),
+    name: 'RPC_URL environment variable, --rpc flag, or positional RPC URL argument'
+  });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+const expectedChainId = resolveExpectedChainId({ flags });
+const allowMismatch = shouldAllowChainMismatch({ flags });
+
+(async () => {
+  try {
+    const provider = new JsonRpcProvider(rpcUrl);
+    const chainIdHex = await provider.send('eth_chainId', []);
+    const normalizedChainId = ensureChainId(chainIdHex, expectedChainId, { allowMismatch });
+
+    const output = {
+      chainId: normalizedChainId,
+      expectedChainId
+    };
+
+    if (allowMismatch && normalizedChainId !== expectedChainId) {
+      output.note = 'Chain id mismatch allowed by configuration';
+    }
+
+    console.log(JSON.stringify(output, null, 2));
+  } catch (error) {
+    console.error(`Failed to query chain id: ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+})();

--- a/scripts/derive-address.js
+++ b/scripts/derive-address.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+
+const { Wallet } = require('ethers');
+const { parseCliArgs, pickInput } = require('./utils');
+
+const { positionals, flags } = parseCliArgs(process.argv.slice(2));
+
+let privateKey;
+try {
+  privateKey = pickInput({
+    envKey: 'PRIVATE_KEY',
+    flagKeys: ['key', 'private-key', 'pk'],
+    flags,
+    positionals,
+    positionalTest: (value) => /^0x[0-9a-fA-F]{64}$/.test(value),
+    name: 'PRIVATE_KEY environment variable, --key flag, or positional private key argument'
+  });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+try {
+  const wallet = new Wallet(privateKey);
+  console.log(wallet.address);
+} catch (error) {
+  console.error(`Failed to derive address: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/send-self-tx.js
+++ b/scripts/send-self-tx.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { JsonRpcProvider, Wallet, formatUnits, parseUnits } = require('ethers');
+const {
+  ensureChainId,
+  extractErrorMessage,
+  maskHex,
+  parseCliArgs,
+  pickInput,
+  resolveExpectedChainId,
+  shouldAllowChainMismatch,
+  timestampForDiagnostics
+} = require('./utils');
+
+const { positionals, flags } = parseCliArgs(process.argv.slice(2));
+
+let rpcUrl;
+let privateKey;
+
+try {
+  rpcUrl = pickInput({
+    envKey: 'RPC_URL',
+    flagKeys: ['rpc', 'rpc-url', 'url', 'provider'],
+    flags,
+    positionals,
+    positionalTest: (value) => typeof value === 'string' && /^(https?:|wss?:)/i.test(value),
+    name: 'RPC_URL environment variable, --rpc flag, or positional RPC URL argument'
+  });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+try {
+  privateKey = pickInput({
+    envKey: 'PRIVATE_KEY',
+    flagKeys: ['key', 'private-key', 'pk'],
+    flags,
+    positionals,
+    positionalTest: (value) => /^0x[0-9a-fA-F]{64}$/.test(value),
+    name: 'PRIVATE_KEY environment variable, --key flag, or positional private key argument'
+  });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+const toOverride = pickInput({
+  envKey: 'SELF_TX_TO',
+  flagKeys: ['to', 'to-address', 'recipient'],
+  flags,
+  positionals,
+  positionalTest: (value) => /^0x[0-9a-fA-F]{40}$/.test(value),
+  optional: true
+});
+
+const valueInput = pickInput({
+  envKey: 'SELF_TX_VALUE',
+  flagKeys: ['value', 'amount', 'eth'],
+  flags,
+  positionals,
+  positionalTest: (value) => {
+    if (typeof value !== 'string') {
+      return false;
+    }
+    if (/^0x[0-9a-fA-F]{64}$/.test(value)) {
+      return false;
+    }
+    if (/^(https?:|wss?:)/i.test(value)) {
+      return false;
+    }
+    return /^-?\d+(\.\d+)?$/.test(value.trim());
+  },
+  optional: true
+});
+
+let valueWei;
+try {
+  valueWei = parseUnits(valueInput || '0', 'ether');
+} catch (error) {
+  console.error(`Invalid value amount: ${extractErrorMessage(error)}`);
+  process.exit(1);
+}
+
+const expectedChainId = resolveExpectedChainId({ flags });
+const allowMismatch = shouldAllowChainMismatch({ flags });
+
+const confirmationsInput = process.env.TX_CONFIRMATIONS || flags.confirmations;
+const confirmations = Number.isFinite(Number(confirmationsInput)) && Number(confirmationsInput) >= 0
+  ? Number(confirmationsInput)
+  : 1;
+
+const diagnosticsDir = path.join(process.cwd(), 'diagnostics');
+
+(async () => {
+  try {
+    const provider = new JsonRpcProvider(rpcUrl);
+    const reportedChainId = await provider.send('eth_chainId', []);
+    const chainId = ensureChainId(reportedChainId, expectedChainId, { allowMismatch });
+
+    if (allowMismatch && chainId !== expectedChainId) {
+      console.warn(`Connected chain id ${chainId} differs from expected ${expectedChainId}, proceeding anyway.`);
+    }
+
+    const wallet = new Wallet(privateKey, provider);
+    const from = await wallet.getAddress();
+    const to = toOverride || from;
+
+    const feeData = await provider.getFeeData();
+    const tip = feeData.maxPriorityFeePerGas ?? parseUnits('1.5', 'gwei');
+    const base = feeData.maxFeePerGas ?? feeData.gasPrice ?? parseUnits('2', 'gwei');
+    const max = base * 2n;
+
+    const nonce = await provider.getTransactionCount(from, 'pending');
+
+    let gasLimit = 21000n;
+    try {
+      gasLimit = await provider.estimateGas({ from, to: from, value: 0 });
+    } catch (estimateError) {
+      console.warn(`Gas estimation failed, using default 21000: ${extractErrorMessage(estimateError)}`);
+    }
+
+    const tx = {
+      to,
+      value: valueWei,
+      type: 2,
+      maxPriorityFeePerGas: tip,
+      maxFeePerGas: max,
+      gasLimit,
+      nonce
+    };
+
+    const response = await wallet.sendTransaction(tx);
+    const receipt = await response.wait(confirmations);
+
+    const now = timestampForDiagnostics();
+    const filePath = path.join(diagnosticsDir, `tx_${now}.json`);
+
+    const output = {
+      phase: 'self-tx',
+      network: chainId,
+      from: maskHex(from),
+      to: maskHex(to),
+      value_wei: valueWei.toString(),
+      value_eth: formatUnits(valueWei, 'ether'),
+      gas_limit: gasLimit.toString(),
+      max_fee_gwei: Number(formatUnits(max, 'gwei')).toFixed(2),
+      max_priority_gwei: Number(formatUnits(tip, 'gwei')).toFixed(2),
+      tx_hash: maskHex(response.hash),
+      tx_hash_full: response.hash,
+      block: receipt?.blockNumber ?? null,
+      status: receipt?.status === 1 ? 'OK' : (receipt?.status === 0 ? 'FAILED' : 'PENDING')
+    };
+
+    fs.mkdirSync(diagnosticsDir, { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(output, null, 2));
+
+    console.log(JSON.stringify({
+      status: output.status,
+      explorer: `https://sepolia.basescan.org/tx/${output.tx_hash_full}`,
+      saved: path.relative(process.cwd(), filePath)
+    }));
+  } catch (error) {
+    console.error(JSON.stringify({
+      status: 'ERROR',
+      reason: extractErrorMessage(error).slice(0, 200)
+    }));
+    process.exit(1);
+  }
+})();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const DEFAULT_CHAIN_ID = '0x14a34';
+
+const normalizeHex = (value) => (typeof value === 'string' ? value.toLowerCase() : '');
+
+const parseCliArgs = (argv) => {
+  const positionals = [];
+  const flags = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (typeof arg !== 'string') {
+      continue;
+    }
+
+    if (arg === '--') {
+      positionals.push(...argv.slice(index + 1));
+      break;
+    }
+
+    if (!arg.startsWith('--')) {
+      positionals.push(arg);
+      continue;
+    }
+
+    const separatorIndex = arg.indexOf('=');
+    if (separatorIndex !== -1) {
+      const key = arg.slice(2, separatorIndex);
+      const value = arg.slice(separatorIndex + 1);
+      flags[key] = value === '' ? true : value;
+      continue;
+    }
+
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+
+    if (typeof next === 'string' && next !== '--' && !next.startsWith('-')) {
+      flags[key] = next;
+      index += 1;
+    } else {
+      flags[key] = true;
+    }
+  }
+
+  return { positionals, flags };
+};
+
+const normalizeCandidate = (value) => (value === undefined || value === null ? undefined : String(value));
+
+const pickInput = ({
+  envKey,
+  flagKeys,
+  flags,
+  positionals,
+  index,
+  name,
+  positionalTest,
+  optional = false,
+  fallback
+}) => {
+  const candidates = [];
+
+  if (Array.isArray(flagKeys) && flags) {
+    for (const key of flagKeys) {
+      if (Object.prototype.hasOwnProperty.call(flags, key)) {
+        candidates.push(flags[key]);
+        break;
+      }
+    }
+  } else if (flagKeys && flags && Object.prototype.hasOwnProperty.call(flags, flagKeys)) {
+    candidates.push(flags[flagKeys]);
+  }
+
+  if (envKey && process.env[envKey]) {
+    candidates.push(process.env[envKey]);
+  }
+
+  if (typeof index === 'number' && positionals && Object.prototype.hasOwnProperty.call(positionals, index)) {
+    candidates.push(positionals[index]);
+  }
+
+  if (typeof positionalTest === 'function' && positionals) {
+    const match = positionals.find((value, valueIndex) => {
+      if (typeof index === 'number' && valueIndex === index) {
+        return false;
+      }
+      return positionalTest(value);
+    });
+
+    if (match !== undefined) {
+      candidates.push(match);
+    }
+  }
+
+  if (fallback !== undefined) {
+    candidates.push(fallback);
+  }
+
+  const resolved = candidates
+    .map(normalizeCandidate)
+    .find((candidate) => candidate && candidate !== 'true');
+
+  if (!resolved) {
+    if (optional) {
+      return undefined;
+    }
+    throw new Error(`Missing ${name}`);
+  }
+
+  return resolved;
+};
+
+const extractErrorMessage = (error) => {
+  if (!error) {
+    return 'Unknown error';
+  }
+
+  if (error.info && error.info.error && error.info.error.message) {
+    return error.info.error.message;
+  }
+
+  if (error.error && error.error.message) {
+    return error.error.message;
+  }
+
+  let message = error.message || error.code || error.name || String(error);
+
+  if (Array.isArray(error.errors) && error.errors.length > 0) {
+    const nested = error.errors
+      .map((inner) => extractErrorMessage(inner))
+      .join('; ');
+    message = `${message} (${nested})`;
+  }
+
+  return message;
+};
+
+const maskHex = (value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  return value.replace(/(0x[0-9a-fA-F]{6}).+/, '$1…');
+};
+
+const timestampForDiagnostics = () => new Date().toISOString().replace(/[-:TZ.]/g, '').slice(0, 14);
+
+const resolveExpectedChainId = ({ flags } = {}) => normalizeHex(
+  process.env.EXPECT_CHAIN_ID || (flags && flags['expect-chain-id']) || DEFAULT_CHAIN_ID
+);
+
+const shouldAllowChainMismatch = ({ flags } = {}) => {
+  const truthyValues = new Set(['1', 'true', 'yes', 'on']);
+
+  if (process.env.ALLOW_CHAIN_MISMATCH) {
+    return truthyValues.has(process.env.ALLOW_CHAIN_MISMATCH.toLowerCase());
+  }
+
+  if (!flags) {
+    return false;
+  }
+
+  const flagValue = flags['allow-chain-mismatch'];
+
+  if (flagValue === true) {
+    return true;
+  }
+
+  if (typeof flagValue === 'string') {
+    return truthyValues.has(flagValue.toLowerCase());
+  }
+
+  return false;
+};
+
+const ensureChainId = (actual, expected, { allowMismatch } = {}) => {
+  const normalizedActual = normalizeHex(actual);
+  const normalizedExpected = normalizeHex(expected);
+
+  if (!normalizedActual) {
+    throw new Error('RPC did not return a chain id');
+  }
+
+  if (!normalizedExpected || normalizedActual === normalizedExpected || allowMismatch) {
+    return normalizedActual;
+  }
+
+  throw new Error(`Unexpected chain id: ${normalizedActual} (expected ${normalizedExpected})`);
+};
+
+module.exports = {
+  DEFAULT_CHAIN_ID,
+  ensureChainId,
+  extractErrorMessage,
+  maskHex,
+  normalizeHex,
+  parseCliArgs,
+  pickInput,
+  resolveExpectedChainId,
+  shouldAllowChainMismatch,
+  timestampForDiagnostics
+};


### PR DESCRIPTION
## Summary
- teach the shared CLI parser to understand --flag value pairs, flag-based input selection, and ALLOW_CHAIN_MISMATCH=1 semantics
- update the derive, chain-check, and self-transaction helpers to accept --rpc/--key flags, optional recipient & value overrides, and richer diagnostics output
- expand the README with the new invocation styles and add a copy-paste one-shot automation prompt for Base Sepolia self-transactions

## Testing
- ✅ `npm run derive:address`
- ❌ `npm run chain:check -- --rpc http://127.0.0.1:8545 --allow-chain-mismatch` *(fails: no local RPC node available)*
- ❌ `npm run tx:self -- 0x8e2449eb4208E5AEa5572dEdf89Ba00B39f94cc8 0 --rpc http://127.0.0.1:8545 --key $PRIVATE_KEY --allow-chain-mismatch` *(fails: no local RPC node available)*

------
https://chatgpt.com/codex/tasks/task_e_6908cf2749ac832fb266b3f3be7e691a