### PR TITLE
Add trust controls docs and policy-linked event schema

### DIFF
--- a/docs/appendices/payment-received-event-v1.1.md
+++ b/docs/appendices/payment-received-event-v1.1.md
@@ -1,0 +1,56 @@
+# `PaymentReceived` Event — v1.1 (adds `policyId`)
+
+This minor revision binds each paid entitlement to a concrete **rights bundle** via `policyId`, enabling provable linkage between payment, license, and usage receipts.
+
+## Solidity Signature
+```solidity
+event PaymentReceived(
+  bytes32 paymentId,
+  address payer,
+  address payee,
+  address asset,
+  uint256 amount,
+  bytes32 queryId,
+  bytes32 contentHash, // optional for bulk
+  bytes32 policyId,    // NEW in v1.1
+  bool allowed,
+  uint32 reasonCode,
+  uint64 ts
+);
+```
+
+> **Compatibility:** Fields prior to `policyId` are unchanged from v1.0. Off‑chain `UsageReceipt` MUST include `policyId`.
+
+## Versioning & Domain Separation
+- **Event version:** encoded indirectly via ABI changes; index this file from the main doc where v1.0 is shown.
+- **`queryId`:** `keccak256(canonicalQueryJSON | supplierId | version)`.
+- **`policyId`:** `keccak256(license_text_pdf_hash | policy_version | rights_scope)`.
+- **`contentHash`:** hash of bulk artifact (e.g., BLAKE3/sha256 of Parquet).
+
+## Reason Codes
+Same as Trust spec; `0 == ALLOW`. Non‑zero implies a deny decision or post‑facto revocation log.
+
+## EAS Anchoring
+- Daily rollup Merkle root over `UsageReceipt{paymentId, queryId, contentHash?, policyId, allowed, reasonCode, ts}`.
+- Store EAS UID/tx and emit in the Trust summary API.
+
+## Migration Notes
+- Index the event logs under `paymentId` and `(payer, ts)` for fast entitlement checks.
+- Backfill `policyId` for v1.0 events with a special sentinel if needed (e.g., `0x0…001`).
+
+## Example (pseudo‑log)
+```json
+{
+  "paymentId": "0xabc…",
+  "payer": "0x123…",
+  "payee": "0xdef…",
+  "asset": "0xa0b8…",           // USDC
+  "amount": "0.90",
+  "queryId": "0x9f…",
+  "contentHash": null,
+  "policyId": "0x77…",
+  "allowed": true,
+  "reasonCode": 0,
+  "ts": 1731240000
+}
+```

--- a/docs/metrics-dictionary.md
+++ b/docs/metrics-dictionary.md
@@ -1,0 +1,90 @@
+# Basebytes Metrics Dictionary
+
+Canonical definitions for KPIs referenced across the 90‑day plan, pilots, and Trust & Controls.
+
+> **Time basis:** All daily rollups use **UTC** day boundaries. Percentiles use nearest‑rank, ties rounded up.
+
+## Platform & Reliability
+
+### GMV (Gross Merchandise Value)
+- **Definition:** Sum of `amount` (in asset units, reported in USDC equivalents where applicable) for all `PaymentReceived.allowed == true` during the period.
+- **Formula:** `GMV_D = Σ amount_i where event_day(i) == D and allowed_i == true`
+- **Source:** On‑chain `PaymentReceived` events (Router/Splitter).
+- **Granularity:** Hourly, Daily, Monthly.
+
+### Receipt Coverage %
+- **Definition:** Share of allowed payments with a corresponding anchored receipt in the daily Merkle.
+- **Formula:** `coverage_D = anchored_receipts_D / allowed_payments_D`
+- **Source:** Off‑chain `UsageReceipt` store + EAS anchor index.
+- **Target:** **100%**.
+
+### Anchor Freshness %
+- **Definition:** Share of periods where the EAS anchor for day D lands by **00:10 UTC** on D+1.
+- **Formula:** `freshness_7D = (# of days with anchor_ts <= D+1 00:10 UTC) / 7`
+- **Targets:** **≥95% (7D)**, **≥95% (30D)**.
+
+### Time‑to‑Entitlement p95
+- **Definition:** 95th percentile of `(entitlement_grant_ts - onchain_payment_ts)` per transaction.
+- **Source:** On‑chain event timestamp + entitlement service logs.
+- **Target:** **< 1s** p95.
+
+## Commercial
+
+### Trial→Paid Conversion %
+- **Definition:** Share of trial accounts that generate at least one allowed payment within 14 days of first entitlement.
+- **Formula:** `paid_trials / total_trials_started`
+- **Window:** 14‑day cohort.
+
+### Pilot Churn %
+- **Definition:** Share of pilots that do not progress to a paid extension or contract within 14 days of pilot end.
+
+## Market‑Maker / RFQ — Performance
+
+### Quote‑to‑Fill (Q2F) %
+- **Definition:** `fills / quotes` for a symbol/venue window.
+- **Delta:** `ΔQ2F = Q2F_with_Basebytes − Q2F_baseline`
+- **Source:** Stream events + buyer‑provided fill confirmations.
+
+### Markout (bps)
+- **Definition:** Signed price move against the fill after T seconds (e.g., 5s/30s).
+- **Delta:** `ΔMarkout_T = Markout_T_with − Markout_T_without` (lower is better).
+
+### Slippage (bps)
+- **Definition:** `((fillPx − quotedPx) / quotedPx) * 10,000`, signed by side.
+- **Delta:** change versus baseline window.
+
+## Agent / Tool‑Use — Performance
+
+### Task Success Rate (TSR) %
+- **Definition:** Completed tasks / attempted tasks for a fixed task set.
+
+### Retry Rate %
+- **Definition:** Tool invocations that require ≥1 retry / total invocations.
+
+### Latency p95 (ms)
+- **Definition:** 95th percentile end‑to‑end task latency.
+
+## Compliance & Policy
+
+### Deny‑Rate %
+- **Definition:** `denied_payments / total_payments` for a given asset and policy.
+- **Breakdown:** By `reasonCode`, `asset` SKU (e.g., `USDC‑US`, `USDC‑EU`).
+
+### Revocation SLA %
+- **Definition:** Share of revocations applied within contractually defined SLA (e.g., <24h for bulk).
+
+## Dimension Catalog
+- **asset:** stablecoin SKU (e.g., `USDC‑US`, `USDC‑EU`).
+- **supplierId:** provider identifier (wallet or EIP‑55 address).
+- **buyerId:** wallet address or org id.
+- **policyId:** bytes32 identifier of rights bundle.
+- **queryId:** deterministic fingerprint of request parameters (see appendices).
+- **contentHash:** hash of bulk file (when applicable).
+
+---
+
+### Audit Bundle Contents (Export)
+- `receipts_D.ndjson`: all `UsageReceipt` rows for day D.
+- `anchor.json`: Merkle root, EAS UID/tx, timestamp.
+- `inclusion_proofs/…`: one proof per receipt id.
+- `policy_map.json`: `policyId → license hash/version`.

--- a/docs/trust-controls-metrics-spec.md
+++ b/docs/trust-controls-metrics-spec.md
@@ -1,0 +1,87 @@
+# Trust & Controls — Metrics and API Spec (v0.1)
+
+Operational transparency primitives exposed to buyers, providers, and auditors.
+
+## Data Model
+
+### UsageReceipt (off‑chain, anchored daily)
+```json
+{
+  "receiptId": "r_2025-11-10_000001",
+  "paymentId": "0x…",
+  "payer": "0x…",
+  "payee": "0x…",
+  "asset": "USDC-US",
+  "amount": "0.42",
+  "queryId": "0x…",
+  "contentHash": "0x…",
+  "policyId": "0x…",
+  "allowed": true,
+  "reasonCode": 0,
+  "ts": 1731240000
+}
+```
+
+### Daily Anchor Record
+```json
+{
+  "day": "2025-11-10",
+  "merkleRoot": "0x…",
+  "count": 1234567,
+  "easUid": "0x…",
+  "anchorTx": "0x…",
+  "anchoredAt": "2025-11-11T00:06:31Z",
+  "schema": "basebytes.receipt.v1"
+}
+```
+
+### Reason Codes (draft)
+```
+0: ALLOW
+1: KYT_FAIL_SANCTIONS
+2: KYT_FAIL_HIGH_RISK
+3: POLICY_DENY_ASSET
+4: POLICY_DENY_GEOGRAPHY
+5: PROVIDER_REVOKED
+6: FRAUD_SUSPECTED
+7: OTHER
+```
+
+## SLOs
+- **Receipt Coverage:** 100% of allowed payments.
+- **Anchor Freshness:** ≥95% of daily anchors by **00:10 UTC** next day.
+- **Revocation SLA:** Bulk: <24h; Streams: immediate gate at next entitlement.
+- **Availability:** Trust APIs 99.9% monthly.
+
+## Public APIs (read‑only)
+
+### `GET /trust/summary`
+- **Returns:** Coverage %, freshness %, last anchor details, deny‑rate breakdown.
+- **Cache:** 60s.
+
+### `GET /trust/days/:day/anchor`
+- **Returns:** Anchor record for `:day` (UTC).
+
+### `GET /trust/days/:day/receipts.ndjson`
+- **Returns:** Line‑delimited `UsageReceipt` for `:day`.
+- **Note:** PII‑free by design; wallet addresses only.
+
+### `GET /trust/days/:day/proofs/:receiptId`
+- **Returns:** Merkle inclusion proof for a receipt id under the day’s root.
+
+### `GET /trust/denylist/hash`
+- **Returns:** Current deny list digest and version.
+
+### `GET /export/audit-bundle?day=:day`
+- **Returns:** Tarball containing receipts, anchor, and proofs for day `:day`.
+
+## Frontend Widgets
+- **Coverage Tile:** `value: %`, `trend: 7D`.
+- **Freshness Tile:** on‑time anchors 7D/30D.
+- **Revocations Tile:** revocations applied (count), SLA met %.
+- **Receipts Tile:** count, policy breakdown, asset breakdown.
+
+## Security & Privacy
+- No PII; wallet addresses only.
+- Policy text is referenced by `policyId` and a public license hash; the license PDF is downloadable.
+- All endpoints rate‑limited; audit bundle links expire in 24h and are hash‑locked per requester.


### PR DESCRIPTION
## Summary
- add a metrics dictionary that standardizes KPI definitions for pilots and reporting
- document trust controls data model, APIs, and widgets to support transparency surfaces
- version the PaymentReceived event to v1.1 with a policyId that links payments to licenses

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c7995848832fab44160820ef41de)