### PR TITLE
fix: parse dashed CLI values as explicit flag arguments

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -36,7 +36,7 @@ const parseCliArgs = (argv) => {
     const key = arg.slice(2);
     const next = argv[index + 1];
 
-    if (typeof next === 'string' && next !== '--' && !next.startsWith('-')) {
+    if (typeof next === 'string' && next !== '--' && !next.startsWith('--')) {
       flags[key] = next;
       index += 1;
     } else {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import utils from '../scripts/utils.js';
+
+const { parseCliArgs } = utils;
+
+describe('parseCliArgs', () => {
+  it('parses dashed values as flag values when provided as the next token', () => {
+    const { flags } = parseCliArgs(['--amount', '-1', '--to', '0xabc']);
+
+    expect(flags.amount).toBe('-1');
+    expect(flags.to).toBe('0xabc');
+  });
+
+  it('keeps next flag token as boolean flag when no explicit value is provided', () => {
+    const { flags } = parseCliArgs(['--dry', '--rpc', 'https://example-rpc']);
+
+    expect(flags.dry).toBe(true);
+    expect(flags.rpc).toBe('https://example-rpc');
+  });
+});


### PR DESCRIPTION
### Motivation
- The CLI parser incorrectly treated single-dash tokens (for example `-1`) as flags instead of values, causing scripts that pass negative numbers or single-dash values after `--flag` to misbehave.

### Description
- Change `parseCliArgs` in `scripts/utils.js` to accept the next token as a flag value when it is a string that does not start with `--`, and add `tests/utils.test.js` with Vitest cases that verify dashed numeric values are parsed as values and boolean-flag behavior remains intact.

### Testing
- Ran `npm test`, which succeeded: 2 test files ran and all tests passed (13 tests total across `tests/eas-worker-sim.test.js` and `tests/utils.test.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984aa85512c832fb824b64ab071239f)